### PR TITLE
fix/mdr-16-remove-unused-import-in-aboutus

### DIFF
--- a/src/components/Content/About/AboutUsSecondLayer.tsx
+++ b/src/components/Content/About/AboutUsSecondLayer.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import UncontrolledCard from '@/components/Cards/Card'
-import AboutUsCardContent from './AboutUsCardContent'
 
 
 const AboutUsSecondLayer = () => {


### PR DESCRIPTION
Hi Team,

Kindly check my PR.

What's changed:

Remove unused import in About Us Second Layer Causing error in deployment CI/CD.
For more info: https://github.com/orgs/Modern-Resolve-Developers/projects/4/views/6?pane=issue&itemId=34007154

Thanks!